### PR TITLE
remove MaxResults

### DIFF
--- a/mysqlebs.py
+++ b/mysqlebs.py
@@ -488,7 +488,6 @@ class MysqlEbsSnapshotManager(object):
             #TODO: paginate results using MaxResults and NextToken
             snapshots = self.ec2.describe_snapshots(Filters=filters)
             self.logger.debug('Retrieved %d snapshots for %s' % (len(snapshots['Snapshots']), vol['VolumeId']))
-            self.logger.debug('NextToken: %s' % snapshots['NextToken'])
             for snapshot in snapshots['Snapshots']:
                 for tag in snapshot['Tags']:
                     if tag['Key'] == 'mysqlebs-dev':


### PR DESCRIPTION
We weren't cleaning up all the snapshots, and it turns out that when we use MaxResults=1000, we only get 35 results and a NextToken. I'm simply removing the MaxResults for now, and writing a Jira ticket to handle paginated results.